### PR TITLE
Add some log statements to report progress

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,18 +38,25 @@ func main() {
 	client := github.NewClient(context.Background(), util.MustEnv("GITHUB_PERSONAL_TOKEN"))
 	r := make(map[string]*repo)
 
+	log.Printf("Loading ignorelist from GitHub...")
 	ignore, err := loadIgnoreSet(client)
 	if err != nil {
 		log.Fatalf("Error loading set of projects to ignore: %s", err)
 	}
+	log.Printf("Ignorelist of %d entries loaded.", len(ignore))
 
 	for _, pkg := range packages {
 		pkg = "github.com/hashicorp/terraform/" + pkg
+
+		log.Printf("Discovering importers of %q on godoc ... ", pkg)
 		importers, err := godoc.ListImporters(pkg, ignore, true)
 		if err != nil {
 			log.Fatalf("Error fetching importers of %s: %s", pkg, err)
 		}
+		log.Printf("%d found.", len(importers))
+
 		for _, imp := range importers {
+			log.Printf("Processing %q ...", imp)
 			// non github repos will have the full package path
 			// it will be unclear to us where the project namespace begins
 			// and where the package tree begins
@@ -67,7 +74,7 @@ func main() {
 				r[proj] = &repo{
 					Stars: stars,
 					Packages: map[string][]string{
-						imp: []string{pkg},
+						imp: {pkg},
 					},
 				}
 			} else {
@@ -82,20 +89,26 @@ func main() {
 }
 
 func loadIgnoreSet(client *github.Client) (map[string]bool, error) {
+	log.Printf("Listing repositories under %q ...", "terraform-providers")
 	ignoreForksOf, err := client.ListRepositories("terraform-providers")
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("%d repositories found.", len(ignoreForksOf))
+
 	ignoreForksOf = append(ignoreForksOf, "github.com/hashicorp/terraform", "github.com/hashicorp/otto")
 
 	var ignoredForks []string
-	for _, upstream := range ignoreForksOf {
+	for i, upstream := range ignoreForksOf {
+		log.Printf("Listing forks of %q (%d/%d)...", upstream, i+1, len(ignoreForksOf))
 		owner, repo := github.OwnerRepo(upstream)
 		forks, err := client.ListForks(owner, repo)
 		if err != nil {
 			return nil, err
 		}
+		log.Printf("%d forks of %q found.", len(forks), upstream)
 		ignoredForks = append(ignoredForks, forks...)
 	}
+
 	return util.StringListToSet(append(ignoredForks, ignoreForksOf...)), nil
 }


### PR DESCRIPTION
Many operations performed by go-importers can take significant time and these log statement can serve as a "cheap" way to report progress back to the user.

As log output goes to stderr by default, this can be easily suppressed via `2>/dev/null` and therefore the existing interoperability (e.g. piping to `jq`) isn't hurt by this.
